### PR TITLE
fix: clone the src repo & escape $ characters

### DIFF
--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -11,8 +11,9 @@ jobs:
     with:
       rock-name: litmuschaos-server
       # TODO: can we ensure it only gets rebuilt when there's a new release of this component only?
-      source-repo: https://github.com/litmuschaos/litmus
+      source-repo: litmuschaos/litmus
       # litmuschaos is a monorepo, so we'll need a custom script to update the golang version
+      # we need to escape '$' to avoid variable expansions by the shared CI workflow.
       update-script: |
         git clone --depth 1 https://github.com/litmuschaos/litmus.git "\$GITHUB_WORKSPACE/application-src"
         go_version="\$(grep -Po "^go \K(\S+)" "\$GITHUB_WORKSPACE/application-src/chaoscenter/graphql/server/go.mod")"


### PR DESCRIPTION
## Issue
1- The shared CI doesn't clone the application source repo
2- In the shared wf, https://github.com/canonical/observability/blob/main/.github/workflows/rock-update.yaml#L164, we use an unquoted heredoc (`EOF`), which will expand the vars and evaluate expressions before dumping the content in the script. So, for example, it will try to evaluate the `grep` command to fetch the `go.mod` version before even cloning the repo.

## Solution
1- clone the application source repo first
2- Escape all `$` chars
