### PR TITLE
fix: Fixes setting build-snaps in the rock-update workflow

### DIFF
--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -14,6 +14,8 @@ jobs:
       source-repo: https://github.com/litmuschaos/litmus
       # litmuschaos is a monorepo, so we'll need a custom script to update the golang version
       update-script: |
+        # When editing the script, make sure to escape all dollar signs to prevent variables from being evaluated
+        # at the time of saving the script to a file, unless this is the desired behavior.
         go_version="\$(grep -Po "^go \K(\S+)" "$application_src/chaoscenter/graphql/server/go.mod")" \
         # Delete the Go dependency and add the updated one
         yq -i 'del(.parts.litmuschaos-server.build-snaps.[] | select(. == "go/*"))' \


### PR DESCRIPTION
## Issue
https://github.com/canonical/litmuschaos-server-rock/issues/6

## Context
The `update-script` from the `rock-update` workflow is passed to and processed by the shared workflow. The shared workflow saves the script to a file. When this happens, all variables in the script are being evaluated. The problem is that the script is not processed line-by-line but as a whole. As a result only the first variable (`go_version`) is evaluated correctly. Other variables, which depend on `go_version`, become empty strings.

## Solution
Escaping variables in the `update-script` prevents evaluation at the time of writing the script to the file. Variables will be correctly evaluated at run time.



