### PR TITLE
chore: use `backend` as pebble service name

### DIFF
--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -11,7 +11,7 @@ jobs:
     with:
       rock-name: litmuschaos-server
       # TODO: can we ensure it only gets rebuilt when there's a new release of this component only?
-      source-repo: https://github.com/litmuschaos/litmus
+      source-repo: litmuschaos/litmus
       # litmuschaos is a monorepo, so we'll need a custom script to update the golang version
       update-script: |
         # When editing the script, make sure to escape all dollar signs to prevent variables from being evaluated

--- a/3.19.0/rockcraft.yaml
+++ b/3.19.0/rockcraft.yaml
@@ -8,7 +8,7 @@ base: ubuntu@24.04
 license: Apache-2.0
 
 services:
-  litmuschaos-server:
+  backend:
     command: server
     override: replace
     # it will start and error out immediately: it needs several
@@ -28,8 +28,6 @@ parts:
     source-subdir: chaoscenter/graphql/server
     build-snaps:
       - go/1.22/stable
-#    override-build: |
-#      CGO_ENABLED=0 go build -o "${CRAFT_PART_INSTALL}/server" -v
     stage:
       - bin/server
 


### PR DESCRIPTION
Contributes to fixing https://github.com/canonical/litmus-operators/issues/19

## Drive-bys
- fix github upstream source in rock update workflow 
