### PR TITLE
chore(deps): bump litmuschaos-server version to 3.29.0

### DIFF
--- a/3.29.0/rockcraft.yaml
+++ b/3.29.0/rockcraft.yaml
@@ -1,0 +1,48 @@
+# upstream: https://github.com/litmuschaos/litmus/blob/master/chaoscenter/graphql/server/Dockerfile
+
+name: litmuschaos-server
+summary: Petrified litmuschaos-server.
+description: "Litmus server AKA 'graphql server'."
+version: "3.29.0"
+base: ubuntu@24.04
+license: Apache-2.0
+services:
+  backend:
+    command: server
+    override: replace
+    # it will start and error out immediately: it needs several
+    # other components and configurations to function properly.
+    startup: enabled
+platforms:
+  amd64:
+parts:
+  litmuschaos-server:
+    plugin: go
+    source: https://github.com/litmuschaos/litmus
+    source-type: git
+    source-tag: "3.29.0"
+    source-depth: 1
+    source-subdir: chaoscenter/graphql/server
+    build-snaps:
+      - go/1.24/stable
+    override-build: |
+      # write the workload version into a VERSION file
+      echo "$(craftctl get version)" > "${CRAFT_PART_INSTALL}/VERSION"
+      cp -r chaoscenter/graphql/server/manifests ${CRAFT_PART_INSTALL}
+      craftctl default
+    stage:
+      - bin/server
+      - manifests/*
+      - VERSION
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - litmuschaos-server
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/3.29.0/spread/.extension
+++ b/3.29.0/spread/.extension
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+usage() {
+    echo "usage: $(basename "$0") [command]"
+    echo "valid commands:"
+    echo "    allocate              Create a backend instance to run tests on"
+    echo "    discard               Destroy a backend instance used to run tests"
+    echo "    backend-prepare       Set up the system to run tests"
+    echo "    backend-restore       Restore the system after the tests ran"
+    echo "    backend-prepare-each  Prepare the system before each test"
+    echo "    backend-restore-each  Restore the system after each test run"
+}
+
+prepare() {
+    case "$SPREAD_SYSTEM" in
+    fedora*)
+        dnf update -y
+        dnf install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    debian*)
+        apt update
+        apt install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    ubuntu*)
+        apt update
+        ;;
+    esac
+
+    snap wait system seed.loaded
+    snap refresh --hold
+
+    if systemctl is-enabled unattended-upgrades.service; then
+        systemctl stop unattended-upgrades.service
+        systemctl mask unattended-upgrades.service
+    fi
+}
+
+restore() {
+    case "$SPREAD_SYSTEM" in
+    ubuntu* | debian*)
+        apt autoremove -y --purge
+        ;;
+    esac
+
+    rm -Rf "$PROJECT_PATH"
+    mkdir -p "$PROJECT_PATH"
+}
+
+prepare_each() {
+    true
+}
+
+restore_each() {
+    true
+}
+
+allocate_lxdvm() {
+    name=$(echo "$SPREAD_SYSTEM" | tr '[:punct:]' -)
+    system=$(echo "$SPREAD_SYSTEM" | tr / -)
+    if [[ "$system" =~ ^ubuntu- ]]; then
+        image="ubuntu:${system#ubuntu-}"
+    else
+        image="images:$(echo "$system" | tr - /)"
+    fi
+
+    VM_NAME="${VM_NAME:-spread-${name}-${RANDOM}}"
+    DISK="${DISK:-20}"
+    CPU="${CPU:-4}"
+    MEM="${MEM:-8}"
+
+    lxc launch --vm \
+        "${image}" \
+        "${VM_NAME}" \
+        -c limits.cpu="${CPU}" \
+        -c limits.memory="${MEM}GiB" \
+        -d root,size="${DISK}GiB"
+
+    while ! lxc exec "${VM_NAME}" -- true &>/dev/null; do sleep 0.5; done
+    lxc exec "${VM_NAME}" -- sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    lxc exec "${VM_NAME}" -- bash -c "if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' > /etc/ssh/sshd_config.d/00-spread.conf; fi"
+    lxc exec "${VM_NAME}" -- bash -c "echo root:${SPREAD_PASSWORD} | sudo chpasswd || true"
+
+    # Print the instance address to stdout
+    ADDR=""
+    while [ -z "$ADDR" ]; do ADDR=$(lxc ls -f csv | grep "^${VM_NAME}" | cut -d"," -f3 | cut -d" " -f1); done
+    echo "$ADDR" 1>&3
+}
+
+discard_lxdvm() {
+    instance_name="$(lxc ls -f csv | sed ':a;N;$!ba;s/(docker0)\n/(docker0) /' | grep "$SPREAD_SYSTEM_ADDRESS " | cut -f1 -d",")"
+    lxc delete -f "$instance_name"
+}
+
+allocate_ci() {
+    if [ -z "$CI" ]; then
+        echo "This backend is intended to be used only in CI systems."
+        exit 1
+    fi
+    sudo sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/00-spread.conf; fi
+    sudo systemctl daemon-reload
+    sudo systemctl restart ssh
+
+    echo "root:${SPREAD_PASSWORD}" | sudo chpasswd || true
+
+    # Print the instance address to stdout
+    echo localhost >&3
+}
+
+discard_ci() {
+    true
+}
+
+allocate() {
+    exec 3>&1
+    exec 1>&2
+
+    case "$1" in
+    lxd-vm)
+        allocate_lxdvm
+        ;;
+    ci)
+        allocate_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+discard() {
+    case "$1" in
+    lxd-vm)
+        discard_lxdvm
+        ;;
+    ci)
+        discard_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+set -e
+
+while getopts "" o; do
+    case "${o}" in
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+CMD="$1"
+PARM="$2"
+
+if [ -z "$CMD" ]; then
+    usage
+    exit 0
+fi
+
+case "$CMD" in
+allocate)
+    allocate "$PARM"
+    ;;
+discard)
+    discard "$PARM"
+    ;;
+backend-prepare)
+    prepare
+    ;;
+backend-restore)
+    restore
+    ;;
+backend-prepare-each)
+    prepare_each
+    ;;
+backend-restore-each)
+    restore_each
+    ;;
+*)
+    echo "unknown command $CMD" >&2
+    ;;
+esac

--- a/3.29.0/spread/general/ready/task.yaml
+++ b/3.29.0/spread/general/ready/task.yaml
@@ -1,0 +1,7 @@
+summary: Run goss tests
+
+environment:
+  GOSS_FILE: "../../../goss.yaml"
+
+execute: |
+  dgoss run rockcraft-test:latest

--- a/goss.yaml
+++ b/goss.yaml
@@ -1,7 +1,4 @@
-process:
+command:
   server:
-    running: true
-file:
-  /VERSION:
-    exists: true
-    contents: [{{ .Env.VERSION }}]
+    exec: "command -v server"
+    exit-status: 0

--- a/justfile
+++ b/justfile
@@ -1,69 +1,9 @@
-# set quiet # Recipes are silent by default
-set export # Just variables are exported to environment variables
-
-rock_name := `echo ${PWD##*/} | sed 's/-rock//'`
-latest_version := `find . -maxdepth 1 -type d | sort -V | tail -n1 | sed 's@./@@'`
+set allow-duplicate-recipes
+set allow-duplicate-variables
+import? 'rocks.just'
 
 [private]
-default:
+@default:
   just --list
-
-# Push an OCI image to a local registry
-[private]
-push-to-registry version:
-  echo "Pushing $rock_name $version to local registry"
-  rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
-    "oci-archive:${version}/${rock_name}_${version}_amd64.rock" \
-    "docker://localhost:32000/${rock_name}-dev:${version}"
-
-# Pack a rock of a specific version
-pack version=latest_version:
-  cd "$version" && rockcraft pack
-
-# `rockcraft clean` for a specific version
-clean version:
-  cd "$version" && rockcraft clean
-
-# Run a rock and open a shell into it with `kgoss`
-run version=latest_version: (push-to-registry version)
-  kgoss edit -i localhost:32000/${rock_name}-dev:${version}
-
-
-test version=latest_version: (push-to-registry version)
-  # litmuschaos-server needs a MongoDB database to work. deploy one
-  kubectl delete service mongo --ignore-not-found
-  kubectl delete pod mongo --ignore-not-found
-
-  kubectl run mongo \
-    --image=mongo:7 \
-    --env="MONGO_INITDB_ROOT_USERNAME=root" \
-    --env="MONGO_INITDB_ROOT_PASSWORD=password" \
-    --port=27017
-  kubectl expose pod mongo \
-    --port=27017 \
-    --name=mongo
-
-  kgoss run -i "localhost:32000/litmuschaos-server-dev:$version" \
-      -e DB_USER=root \
-      -e VERSION="$version" \
-      -e DB_PASSWORD=password \
-      -e REST_PORT=3000 \
-      -e GRPC_PORT=3030 \
-      -e DB_SERVER=mongodb://mongo:27017 \
-      -e ADMIN_USERNAME=admin \
-      -e ADMIN_PASSWORD=password \
-      -e INFRA_DEPLOYMENTS='["app=chaos-exporter"]' \
-      -e SUBSCRIBER_IMAGE="litmuschaos/litmusportal-subscriber:$version" \
-      -e EVENT_TRACKER_IMAGE="litmuschaos/litmusportal-event-tracker:$version" \
-      -e ARGO_WORKFLOW_CONTROLLER_IMAGE="litmuschaos/workflow-controller:v3.3.1" \
-      -e ARGO_WORKFLOW_EXECUTOR_IMAGE="litmuschaos/argoexec:v3.3.1" \
-      -e LITMUS_CHAOS_OPERATOR_IMAGE="litmuschaos/chaos-operator:$version" \
-      -e LITMUS_CHAOS_RUNNER_IMAGE="litmuschaos/chaos-runner:$version" \
-      -e LITMUS_CHAOS_EXPORTER_IMAGE="litmuschaos/chaos-exporter:$version" \
-      -e CONTAINER_RUNTIME_EXECUTOR="k8sapi" \
-      -e WORKFLOW_HELPER_IMAGE_VERSION="$version" \
-      -e INFRA_COMPATIBLE_VERSIONS="[$version]" \
-      -e DEFAULT_HUB_BRANCH_NAME="master" \
-     
-  kubectl delete service mongo --ignore-not-found
-  kubectl delete pod mongo --ignore-not-found
+  echo ""
+  echo "For help with a specific recipe, run: just --usage <recipe>"

--- a/rocks.just
+++ b/rocks.just
@@ -1,0 +1,228 @@
+# Centralized justfile for the Canonical Observability rocks
+set shell := ["bash", "-uc"]
+
+rock_name := `echo ${PWD##*/} | sed 's/-rock$//'`  # Get the rock name from the folder name
+latest_version := `find . -name rockcraft.yaml -printf '%h\n' | sort -V | tail -n1 | sed 's@./@@'`
+
+# LTS end-of-life overrides. Override this variable in the local 'justfile'.
+# Define mappings from LTS minor versions to their EOL date in YYYY-MM-DD format.
+# Example: lts_releases := '{"2.14": "2026-12-31", "2.12": "2025-06-30"}'
+lts_releases := '{}'
+
+[private]
+@default:
+  just --list
+  echo "{{rock_name}}"
+  echo "For help with a specific recipe, run: just --usage <recipe>"
+
+# Push an OCI image to a local registry
+[private]
+@push-to-registry version=latest_version:
+  which -s docker || { echo "docker not found"; exit 1; }
+  test -f "{{version}}/{{rock_name}}_{{version}}_amd64.rock" || rockcraft pack
+  echo "Pushing {{version}} to local docker registry"
+  cd {{version}}; sudo rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false "oci-archive:{{rock_name}}_{{version}}_amd64.rock" docker-daemon:rockcraft-test:latest
+  echo "✓ Rock pushed to local registry under 'rockcraft-test:latest'"
+
+# Print the rock name
+[group("info")]
+@name:
+  echo "{{rock_name}}"
+
+# Print the latest rock version
+[group("info")]
+@latest-version:
+  echo "{{latest_version}}"
+
+# Pack a rock of a specific component and version
+[group("dev")]
+pack version=latest_version:
+  cd "{{version}}" && rockcraft pack
+
+# `rockcraft clean` for a specific component and version
+[group("dev")]
+clean version=latest_version:
+  cd "{{version}}" && rockcraft clean
+
+# Run a rock and open a shell into it with `docker`
+[group("dev")]
+run version=latest_version: (push-to-registry version)
+  which -s dgoss || { echo "dgoss not found"; exit 1; }
+  dgoss edit rockcraft-test:latest || true
+
+# Test a rock with `rockcraft test`
+[group("dev")]
+test version=latest_version:
+  #!/usr/bin/env bash
+  set -e
+  cp spread.yaml "{{version}}/spread.yaml"
+  if [ -f goss.yaml ]; then cp goss.yaml "{{version}}/goss.yaml"; fi
+  test_exit=0; (cd "{{version}}" && rockcraft test) || test_exit=$?
+  rm -f "{{version}}/spread.yaml" "{{version}}/goss.yaml"
+  if [ "$test_exit" -ne 0 ]; then echo "× rockcraft test failed"; exit "$test_exit"; fi
+  echo "✓ 'rockcraft test' passed."
+
+# Generate SBOM for the rock
+[group("security")]
+sbom version=latest_version:
+  syft {{version}}/*.rock -o "spdx-json={{version}}/rock.sbom.json"
+  @echo "✓ SBOM saved to {{version}}/rock.sbom.json"
+
+# Perform a securiy scan
+[group("security")]
+scan version=latest_version: (sbom version)
+  uvx --from=trivy-py trivy sbom "{{version}}/rock.sbom.json"
+  @echo "✓ Vulnerability scan done"
+
+# Check whether CVEs affect the upstream project
+[group("security")]
+govulncheck source_repo version=latest_version:
+  #!/usr/bin/env bash
+  set -e
+  echo "Cloning {{source_repo}}"
+  which -s govulncheck || { echo "govulncheck not found; install it with:  go install golang.org/x/vuln/cmd/govulncheck@latest"; exit 1; }
+  TMP_DIR="$(mktemp -d)"
+  gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "{{version}}" --depth 1 2>/dev/null \
+    || gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "v{{version}}" --depth 1
+  if [[ ! -f "$TMP_DIR/{{source_repo}}/go.mod" ]]; then
+    echo "⨯ {{source_repo}} is not a Go project (go.mod is missing)"
+    exit 2
+  fi
+  echo "Running 'govulncheck' (this may take a while)"
+  vuln_exit=0; (cd "$TMP_DIR/{{source_repo}}" && govulncheck ./...) || vuln_exit=$?
+  rm -rf "$TMP_DIR"
+  if [ "$vuln_exit" -ne 0 ]; then echo "⨯ 'govulncheck' failed"; exit "$vuln_exit"; fi
+  echo "✓ 'govulncheck' passed."
+
+# Generate a rock for the latest version of the upstream project
+[arg("source_repo", help="Repository of the upstream project in 'org/repo' form")]
+[group("maintenance")]
+update source_repo release_tag="":
+  #!/usr/bin/env bash
+  set -e
+  if [[ -z "{{release_tag}}" ]]; then
+    latest_release="$(gh release list --repo {{source_repo}} --exclude-pre-releases --limit=1 --json tagName --jq '.[0].tagName')"
+    echo "Latest release for {{source_repo}} is $latest_release"
+  else
+    latest_release="{{release_tag}}"
+    echo "Release version manually set to $latest_release"
+  fi
+  # Explicitly filter out prefixes for known rocks, so we can notice if a new rock has a different schema
+  version="${latest_release}"
+  version="${version#mimir-}"  # mimir
+  version="${version#cmd/builder/v}"  # opentelemetry-collector
+  version="${version#v}"  # Generic v- prefix
+  # If the version already exists as a rock, exit here
+  if [[ -d "$version" ]]; then echo "Folder $version already exists, nothing to do" && exit 0; fi
+  # Create the folder for the new version and update the rockcraft.yaml
+  cp -r "{{latest_version}}" "$version"
+  latest_release="$latest_release" version="$version" yq -i \
+    '.version = strenv(version) | .parts.{{rock_name}}["source-tag"] = strenv(latest_release)' \
+    "./$version/rockcraft.yaml"
+  # Automatically update build tools (go) from the upstream repository
+  TMP_DIR="$(mktemp -d)"
+  gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "$latest_release" --depth 1
+  # If it's a Go project, update the Go version
+  if [[ -f "$TMP_DIR/{{source_repo}}/go.mod" ]]; then
+    go_snap_version="$(grep -Po '^go \K(\S+)' "$TMP_DIR/{{source_repo}}/go.mod" | sed -E 's/([0-9]+\.[0-9]+).*/\1/')"
+    go_snap_version="$go_snap_version" yq -i \
+      '(.parts.{{rock_name}}.build-snaps[] | select(test("^go/"))) = "go/"+strenv(go_snap_version)+"/candidate"' \
+      "./$version/rockcraft.yaml"
+  fi
+  rm -rf "$TMP_DIR"
+  echo "✓ Created rock for version $version"
+
+# Fetch centralized files from canonical/observability
+[group("maintenance")]
+refresh:
+  #!/usr/bin/env bash
+  which -s gh || { echo "gh not found"; exit 1; }
+  refresh_folder="blueprints/rocks"
+  api_path="repos/canonical/observability/contents/$refresh_folder"
+  for file in rocks.just spread.yaml; do
+    echo "Fetching latest '$file' from canonical/observability ..."
+    gh api "$api_path/$file" --jq '.content' | base64 --decode > "$file"
+    echo "✓ $file updated"
+  done
+
+# Release rock to GHCR with tag `:dev`
+[group("release")]
+release-ghcr version=latest_version github_user="observability-noctua-bot":
+  #!/usr/bin/env bash
+  set -e
+  if [[ -z "$GITHUB_TOKEN" ]]; then echo "× Please export GITHUB_TOKEN for the user {{github_user}}"; exit 1; fi
+  if [ ! -e {{version}}/*.rock ]; then echo "× Error: rock not found. Please run 'just pack {{version}}' first."; exit 2; fi
+  sudo rockcraft.skopeo --insecure-policy copy \
+    "oci-archive:$(realpath ./{{version}}/*.rock)" \
+    "docker://ghcr.io/canonical/{{rock_name}}:dev" \
+    --dest-creds "{{github_user}}:${GITHUB_TOKEN}"
+  echo "✓ {{rock_name}} {{version}} pushed to GHCR with tag ':dev'"
+
+# Open a PR to OCI Factory
+[group("release")]
+[arg("support",pattern="major|minor|patch")]
+[arg("risk", pattern="stable|candidate|beta|edge")]
+release-oci-factory version=latest_version support="minor" risk="stable":
+  #!/usr/bin/env bash
+  set -e
+  if [[ -z "$GITHUB_TOKEN" ]]; then echo "× Please export GITHUB_TOKEN for the user observability-noctua-bot"; exit 1; fi
+  if [ ! -e {{version}}/*.rock ]; then echo "× Error: rock not found. Please run 'just pack {{version}}' first."; exit 2; fi
+  repository="$(git remote get-url origin | sed -E 's#(git@[^:]+:|https?://[^/]+/)##; s/\.git$//')"
+  # Extract the base from the rockcraft.yaml (e.g. "ubuntu@24.04" -> "24.04")
+  # For bare-based rocks, fall back to build-base (e.g. "ubuntu@26.04" -> "26.04")
+  rock_base="$(yq -r '.base' "{{version}}/rockcraft.yaml" | sed 's/.*@//')"
+  if [[ "$rock_base" == "bare" ]]; then
+    rock_base="$(yq -r '.["build-base"]' "{{version}}/rockcraft.yaml" | sed 's/.*@//')"
+  fi
+  echo "Detected base: $rock_base"
+  # Clone the oci-factory and push data to it
+  gh repo sync --force observability-noctua-bot/oci-factory
+  TMP_DIR="$(mktemp -d)"
+  git clone https://github.com/observability-noctua-bot/oci-factory "$TMP_DIR/oci-factory"
+  echo "✓ Cloned observability-noctua-bot/oci-factory"
+  # Build the OCI Factory manifest
+  # Check if this version has a custom EOL in lts_releases
+  minor_version="$(echo "{{version}}" | grep -oP '^\d+\.\d+')"
+  eol_date="$(echo '{{lts_releases}}' | jq -r --arg v "$minor_version" '.[$v] // empty')"
+  eol_flag=""
+  if [[ -n "$eol_date" ]]; then
+    eol_flag="--eol=$eol_date"
+    echo "LTS release detected: EOL set to $eol_date"
+  fi
+  echo "Building the OCI Factory manifest..."; echo
+  manifest_file="$TMP_DIR/oci-factory/oci/{{rock_name}}/image.yaml"
+  uvx --from=git+https://github.com/lucabello/noctua noctua rock manifest \
+    "$repository" \
+    --commit="$(git rev-parse HEAD)" \
+    --base="$rock_base" \
+    --support="{{support}}" \
+    --risk="{{risk}}" \
+    --version="{{version}}" \
+    $eol_flag \
+    | tee "$manifest_file"
+  echo; echo "✓ OCI Factory manifest generated"
+  # If there's nothing to upload, exit early
+  upload_count="$(cat "$manifest_file" | yq '.upload | length')"
+  if [[ "$upload_count" -eq 0 ]]; then
+    echo "✓ Nothing to update in OCI Factory"
+    rm -rf "$TMP_DIR"
+    exit 0
+  fi
+  # Commit the changes and create a PR
+  pushd "$TMP_DIR/oci-factory" >/dev/null
+  git config user.name observability-noctua-bot
+  git config user.email webops+observability-noctua-bot@canonical.com
+  git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/observability-noctua-bot/oci-factory.git"
+  branch_name="update-$(date -d now +%s)"
+  git checkout -b "$branch_name"
+  git add oci/{{rock_name}}/image.yaml
+  git commit -m "chore: Add new {{rock_name}} releases"
+  git push -u origin "$branch_name" --force
+  echo "✓ Changes have been pushed to ${branch_name}"
+  gh pr create --repo canonical/oci-factory \
+    --head "observability-noctua-bot:${branch_name}" \
+    --title "chore: Add new {{rock_name}} releases" \
+    --body "This is an automatic PR opened by the Observability Noctua bot."
+  popd >/dev/null
+  rm -rf "$TMP_DIR"
+  echo "✓ Release to OCI Factory completed"

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,39 @@
+project: rock
+
+backends:
+  craft:
+    type: craft
+    systems:
+      - ubuntu-24.04:
+      #- ubuntu-22.04:
+
+suites:
+  spread/general/:
+    summary: General integration tests
+    environment:
+      # Goss environment
+      GOSS_OPTS: "--retry-timeout=60s"
+      GOSS_FILES_STRATEGY: cp
+      DGOSS_TEMP_DIR: "$HOME"
+
+    prepare: |
+      # Install dependencies
+      sudo snap install docker
+      curl -fsSL https://goss.rocks/install | sh
+
+      # For 'rockcraft.skopeo'
+      sudo snap install --classic rockcraft
+
+      # Wait for docker daemon to come online
+      for i in $(seq 1 10); do docker info >/dev/null 2>&1 && break || sleep 2; done
+
+      # Load the rock into docker
+      sudo rockcraft.skopeo --insecure-policy copy "oci-archive:$CRAFT_ARTIFACT" docker-daemon:rockcraft-test:latest
+      
+    restore: |
+      docker image rm --force rockcraft-test:latest
+
+exclude:
+  - .git
+
+kill-timeout: 1h


### PR DESCRIPTION
## Issue
Closes #39. Addresses vulnerabilities from #37.

## Solution
Add `3.29.0/rockcraft.yaml`, bumping the rock to upstream litmus 3.29.0.

## Context
Verified in the built rock: `grpc` is now v1.79.3 (fixes CRITICAL CVE-2026-33186) and the binary is built with Go 1.24.x (fixes stdlib CVEs). Note: `argo-workflows` (v3.3.5) and `go-git` (v5.13.0) are unchanged upstream, so those CVEs may persist — re-scan after release.

## Testing Instructions
`just pack 3.29.0` then `just test 3.29.0`.